### PR TITLE
Migrate Azure OpenAI to v1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,9 @@ outputs:
 ### Environment Variables
 
 ```bash
-# Azure OpenAI
+# Azure OpenAI (v1 API - no api_version required)
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
 AZURE_OPENAI_API_KEY=your-api-key
-AZURE_OPENAI_API_VERSION=2024-02-15-preview
 
 # OpenAI
 OPENAI_API_KEY=your-api-key

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -46,10 +46,9 @@ cp config/.env.example .env
 The `.env` file stores your API credentials:
 
 ```bash
-# Azure OpenAI (for enterprise deployments)
+# Azure OpenAI (for enterprise deployments, using v1 API)
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
 AZURE_OPENAI_API_KEY=your-api-key
-AZURE_OPENAI_API_VERSION=2024-02-15-preview
 
 # OpenAI (direct API)
 OPENAI_API_KEY=sk-your-key-here

--- a/config/.env.example
+++ b/config/.env.example
@@ -1,7 +1,6 @@
-# Azure OpenAI Configuration
+# Azure OpenAI Configuration (v1 API - no api_version required)
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
 AZURE_OPENAI_API_KEY=your-azure-api-key
-AZURE_OPENAI_API_VERSION=2024-02-15-preview
 
 # OpenAI Configuration
 OPENAI_API_KEY=your-openai-api-key

--- a/config/minimal_benchmark.yaml
+++ b/config/minimal_benchmark.yaml
@@ -1,0 +1,25 @@
+benchmark:
+  name: "minimal-benchmark"
+  version: "1.0.0"
+  runs: 1  # Number of times to repeat the evaluation
+
+evaluators:
+  gpt5:
+    provider: "azure_openai"
+    model: "gpt-5"  # Your Azure deployment name
+    temperature: 0.0
+    max_tokens: 500
+
+metrics:
+  - name: "clarity"
+    version: "1.0"
+    evaluators: ["gpt5"]
+    enabled: true
+
+inputs:
+  quiz_directory: "data/quizzes"
+  source_directory: "data/inputs"
+
+outputs:
+  results_directory: "data/results"
+  aggregate: true

--- a/src/evaluators/azure_openai.py
+++ b/src/evaluators/azure_openai.py
@@ -1,15 +1,20 @@
-"""Azure OpenAI provider implementation."""
+"""Azure OpenAI provider implementation using the v1 API."""
 
 import os
 from typing import Any, Optional
 
-from langchain_openai import AzureChatOpenAI
+from langchain_openai import ChatOpenAI
 
 from .base import LLMProvider
 
 
 class AzureOpenAIProvider(LLMProvider):
-    """Azure OpenAI implementation of LLM provider."""
+    """Azure OpenAI implementation of LLM provider using the v1 API.
+
+    This implementation uses the new Azure OpenAI v1 API (GA August 2025)
+    which provides a unified interface compatible with the standard OpenAI client.
+    No api_version parameter is required with this approach.
+    """
 
     def __init__(
         self,
@@ -27,26 +32,27 @@ class AzureOpenAIProvider(LLMProvider):
             **kwargs: Additional parameters
 
         Environment variables required:
-            AZURE_OPENAI_ENDPOINT: Azure OpenAI endpoint URL
+            AZURE_OPENAI_ENDPOINT: Azure OpenAI endpoint URL (without /openai/v1 suffix)
             AZURE_OPENAI_API_KEY: API key
-            AZURE_OPENAI_API_VERSION: API version (optional)
         """
         super().__init__(model, temperature, max_tokens, **kwargs)
 
         endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
         api_key = os.getenv("AZURE_OPENAI_API_KEY")
-        api_version = os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview")
 
         if not endpoint or not api_key:
             raise ValueError(
                 "AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_API_KEY must be set in environment"
             )
 
-        self.llm = AzureChatOpenAI(
-            azure_deployment=model,
-            azure_endpoint=endpoint,
+        # Construct the v1 API base URL
+        # Remove trailing slash if present, then append /openai/v1
+        base_url = endpoint.rstrip("/") + "/openai/v1"
+
+        self.llm = ChatOpenAI(
+            model=model,
+            base_url=base_url,
             api_key=api_key,
-            api_version=api_version,
             temperature=temperature,
             max_tokens=max_tokens,
             **kwargs,
@@ -74,8 +80,14 @@ class AzureOpenAIProvider(LLMProvider):
         if temperature is not None or max_tokens is not None:
             temp = temperature if temperature is not None else self.temperature
             tokens = max_tokens if max_tokens is not None else self.max_tokens
-            llm = AzureChatOpenAI(
-                azure_deployment=self.model,
+
+            endpoint = os.getenv("AZURE_OPENAI_ENDPOINT", "")
+            base_url = endpoint.rstrip("/") + "/openai/v1"
+
+            llm = ChatOpenAI(
+                model=self.model,
+                base_url=base_url,
+                api_key=os.getenv("AZURE_OPENAI_API_KEY"),
                 temperature=temp,
                 max_tokens=tokens,
                 **{**self.additional_params, **kwargs},


### PR DESCRIPTION
# Summary
- Migrate from legacy Azure OpenAI API to the new v1 API (GA August 2025)
- Remove `AZURE_OPENAI_API_VERSION` environment variable requirement
- Simplify Azure OpenAI client configuration using standard ChatOpenAI class

# Changes
- src/evaluators/azure_openai.py: Switch from `AzureChatOpenAI` to `ChatOpenAI` with v1 API base URL
- .env and config/.env.example: Remove `AZURE_OPENAI_API_VERSION`
- README.md and USAGE_GUIDE.md: Update documentation to reflect simplified configuration

# Benefits
- No need to track and update API versions manually
- Automatic access to latest features without config changes
- Cleaner, more portable code using the standard OpenAI client interface
- Reduced configuration complexity

# Migration Notes
Users upgrading from the previous version can simply remove the `AZURE_OPENAI_API_VERSION` line from their .env file. No other changes required.