### PR TITLE
Improve logging

### DIFF
--- a/docs/docs/contributor-guide/architecture.md
+++ b/docs/docs/contributor-guide/architecture.md
@@ -370,9 +370,12 @@ paper-al-quiz-generation-benchmark/
 │   │   └── example_quiz.json
 │   │
 │   └── results/                 # Benchmark results
-│       ├── results_<timestamp>.json
-│       ├── aggregated_<timestamp>.json
-│       └── summary_<timestamp>.txt
+│       └── <run-bundle>/
+│           ├── results.json
+│           ├── aggregated.json
+│           ├── summary.txt
+│           ├── metadata.json
+│           └── run.log
 │
 ├── config/
 │   ├── benchmark_example.yaml

--- a/docs/docs/user-manual/example-workflows.md
+++ b/docs/docs/user-manual/example-workflows.md
@@ -41,7 +41,8 @@ EOF
 python main.py --config config/quick_test.yaml
 
 # 3. View results
-cat data/results/summary_*.txt | tail -20
+ls -lt data/results
+cat data/results/<run-bundle>/summary.txt | tail -20
 ```
 
 ---
@@ -63,7 +64,7 @@ import pandas as pd
 from pathlib import Path
 
 # Load results
-results = json.load(open('data/results/aggregated_experiment_comparison_v1.json'))
+results = json.load(open('data/results/experiment_comparison_v1/aggregated.json'))
 
 # Extract evaluator comparisons
 for metric_name, metric_data in results['aggregations'].items():
@@ -74,7 +75,7 @@ EOF
 
 # 3. Generate comparison report
 python scripts/generate_comparison_report.py \
-  --input data/results/aggregated_experiment_comparison_v1.json \
+  --input data/results/experiment_comparison_v1/aggregated.json \
   --output reports/model_comparison.pdf
 ```
 
@@ -118,7 +119,7 @@ EOF
 python main.py --config config/test_new_metric.yaml --output-prefix dev_v1
 
 # 3. Review results and identify issues
-cat data/results/summary_dev_v1.txt
+cat data/results/dev_v1/summary.txt
 
 # 4. Refine metric implementation
 # Edit src/metrics/my_new_metric.py
@@ -131,8 +132,8 @@ python main.py --config config/test_new_metric.yaml --output-prefix dev_v2
 python << 'EOF'
 import json
 
-v1 = json.load(open('data/results/aggregated_dev_v1.json'))
-v2 = json.load(open('data/results/aggregated_dev_v2.json'))
+v1 = json.load(open('data/results/dev_v1/aggregated.json'))
+v2 = json.load(open('data/results/dev_v2/aggregated.json'))
 
 print("Version comparison:")
 print(f"v0.1 mean: {v1['aggregations']['my_new_metric']['gpt4']['mean']:.2f}")
@@ -161,7 +162,7 @@ python main.py \
 
 # 3. Generate comprehensive reports
 python scripts/generate_report.py \
-  --results data/results/aggregated_prod_eval_*.json \
+  --results data/results/prod_eval_$(date +%Y%m%d)/aggregated.json \
   --format pdf \
   --include-visualizations \
   --output reports/production_evaluation_$(date +%Y%m%d).pdf
@@ -180,4 +181,3 @@ python scripts/send_notification.py \
 ```
 
 ---
-

--- a/docs/docs/user-manual/quick-start.md
+++ b/docs/docs/user-manual/quick-start.md
@@ -146,17 +146,23 @@ python main.py --config config/benchmark_example.yaml
 
 ### Viewing Results
 
-Results are saved to `data/results/`:
+Each run creates a readable bundle directory in `data/results/`:
 
 ```bash
-# View the human-readable summary
-cat data/results/summary_*.txt
+# List recent bundles
+ls -lt data/results
 
-# View raw JSON results
-cat data/results/results_*.json
+# Inspect one bundle
+cat data/results/<run-bundle>/summary.txt
+cat data/results/<run-bundle>/results.json
+cat data/results/<run-bundle>/aggregated.json
+cat data/results/<run-bundle>/run.log
+```
 
-# View aggregated statistics
-cat data/results/aggregated_*.json
+Use `--debug` to stream verbose logs live in terminal:
+
+```bash
+python main.py --config config/benchmark_example.yaml --debug
 ```
 
 ### What's Happening?

--- a/docs/docs/user-manual/troubleshooting.md
+++ b/docs/docs/user-manual/troubleshooting.md
@@ -57,7 +57,7 @@ pip install -r requirements.txt --upgrade
 **Symptoms**: Scores don't match manual assessment
 
 **Diagnostic steps**:
-1. Review raw LLM responses in `results_*.json`
+1. Review raw LLM responses in `<run-bundle>/results.json`
 2. Test metric prompt manually in LLM playground
 3. Verify source material quality and completeness
 4. Check if questions align with learning objectives
@@ -84,4 +84,3 @@ pip install -r requirements.txt --upgrade
 - Clear results between runs
 
 ---
-

--- a/docs/docs/user-manual/usage-guide.md
+++ b/docs/docs/user-manual/usage-guide.md
@@ -344,8 +344,11 @@ python main.py --config config/my_benchmark.yaml --env .env.production
 # Skip aggregation (save only raw results)
 python main.py --config config/my_benchmark.yaml --no-aggregate
 
-# Custom output filename prefix
+# Custom run bundle name
 python main.py --config config/my_benchmark.yaml --output-prefix experiment_001
+
+# Stream verbose debug logs in terminal
+python main.py --config config/my_benchmark.yaml --debug
 ```
 
 #### What Happens During Execution
@@ -377,56 +380,27 @@ python main.py --config config/my_benchmark.yaml --output-prefix experiment_001
    - Generates summary report
 
 5. **Output**
-   - Saves raw results JSON
-   - Saves aggregated results JSON
-   - Saves human-readable summary
+   - Creates a run bundle directory in `outputs.results_directory`
+   - Saves `results.json`, `aggregated.json` (unless `--no-aggregate`), `summary.txt`, `metadata.json`
+   - Saves a full execution log in `run.log`
 
 #### Progress Monitoring
 
-The framework prints progress information:
-
-```
-Registering metrics...
-Available metrics: ['alignment', 'cognitive_level', 'clarity', 'distractor_quality']
-
-Loading configuration from config/benchmark_example.yaml...
-Configuration loaded: example-benchmark v1.0.0
-  Runs: 3
-  Evaluators: ['gpt4', 'gpt35']
-  Metrics: ['alignment', 'clarity', 'distractor_quality']
-
-Initializing benchmark runner...
-  Initialized evaluator: gpt4 (gpt-4)
-  Initialized evaluator: gpt35 (gpt-3.5-turbo)
-  Initialized metric: alignment v1.0
-  Initialized metric: clarity v1.0
-  Initialized metric: distractor_quality v1.0
-
-Starting benchmark execution...
-Loading quizzes from data/quizzes...
-  Loaded 1 quizzes
-
-============================================================
-Starting Run 1/3
-============================================================
-Evaluating quiz: Python Fundamentals Quiz (quiz_example_001)
-  Running alignment with gpt4...
-  Running alignment with gpt35...
-  Running clarity with gpt4...
-  Running clarity with gpt35...
-  Running distractor_quality with gpt4...
-...
-```
+- Default terminal output shows concise run progress (`INFO` level).
+- Full detailed logs are always written to each run bundle (`run.log`).
+- Use `--debug` if you want full verbose logs live in terminal.
 
 ### Understanding Results
 
 #### Output Files
 
-After execution, you'll find three files in `data/results/`:
+After execution, you'll find one run bundle directory in `data/results/` per benchmark run:
 
-1. **`results_<timestamp>.json`** — Raw results from all evaluations
-2. **`aggregated_<timestamp>.json`** — Statistical aggregations
-3. **`summary_<timestamp>.txt`** — Human-readable report
+1. **`results.json`** — Raw results from all evaluations
+2. **`aggregated.json`** — Statistical aggregations (if aggregation enabled)
+3. **`summary.txt`** — Human-readable report
+4. **`metadata.json`** — Run metadata (config, timestamps, run id)
+5. **`run.log`** — Full detailed execution log
 
 #### Reading the Summary
 

--- a/main.py
+++ b/main.py
@@ -2,8 +2,10 @@
 """Main entry point for the quiz benchmark framework."""
 
 import argparse
-import sys
 import json
+import logging
+import re
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -17,6 +19,7 @@ from src.metrics.clarity import ClarityMetric
 from src.runners.benchmark import BenchmarkRunner
 from src.utils.config_loader import ConfigLoader
 from src.utils.io import IOUtils
+from src.utils.logging_utils import setup_logging
 
 
 def register_metrics() -> None:
@@ -69,61 +72,97 @@ def main() -> int:
         "--output-prefix",
         type=str,
         default=None,
-        help="Prefix for output files (default: timestamp)",
+        help="Run bundle name override (default: benchmark-name + timestamp + config hash)",
+    )
+
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable verbose debug logging in terminal",
     )
 
     args = parser.parse_args()
 
     try:
+        setup_logging(debug=args.debug)
+        logger = logging.getLogger(__name__)
+
         # Register metrics
-        print("Registering metrics...")
+        logger.info("Registering metrics...")
         register_metrics()
-        print(f"Available metrics: {MetricRegistry.list_metrics()}")
-        print()
+        logger.debug("Available metrics: %s", MetricRegistry.list_metrics())
 
         # Load configuration
-        print(f"Loading configuration from {args.config}...")
+        logger.info("Loading configuration from %s...", args.config)
         config = ConfigLoader.load_config(args.config, args.env)
-        print(f"Configuration loaded: {config.name} v{config.version}")
-        print(f"Runs: {config.runs}")
-        print(f"Evaluators: {list(config.evaluators.keys())}")
-        print(f"Metrics: {[m.name for m in config.get_enabled_metrics()]}")
-        print()
+        logger.info("Configuration loaded: %s v%s", config.name, config.version)
+        logger.info("Runs: %s", config.runs)
+        logger.info("Evaluators: %s", list(config.evaluators.keys()))
+        logger.info("Metrics: %s", [m.name for m in config.get_enabled_metrics()])
+
+        # Build run bundle directory
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        slug_name = re.sub(r"[^a-zA-Z0-9_-]+", "-", config.name.strip().lower()).strip("-")
+        slug_name = slug_name or "benchmark"
+        run_id = f"{slug_name}-{timestamp}-{ConfigLoader.hash_config(config)[:8]}"
+        run_bundle_name = args.output_prefix or run_id
+
+        results_root = Path(config.input_output.results_directory)
+        run_dir = results_root / run_bundle_name
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        log_file = run_dir / "run.log"
+        setup_logging(debug=args.debug, log_file=log_file)
+        logger = logging.getLogger(__name__)
+
+        logger.info("Run bundle: %s", run_dir)
+        logger.debug("Log file: %s", log_file)
+        logger.debug("Environment file: %s", args.env)
+
+        metadata_file = run_dir / "metadata.json"
+        with open(metadata_file, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "run_bundle": run_bundle_name,
+                    "started_at": datetime.now().isoformat(),
+                    "config_name": config.name,
+                    "config_version": config.version,
+                    "config_hash": ConfigLoader.hash_config(config),
+                    "config_path": str(Path(args.config)),
+                    "env_file": str(Path(args.env)),
+                    "runs": config.runs,
+                    "evaluators": list(config.evaluators.keys()),
+                    "metrics": [m.name for m in config.get_enabled_metrics()],
+                    "debug_mode": args.debug,
+                },
+                f,
+                indent=2,
+            )
 
         # Initialize benchmark runner
-        print("Initializing benchmark runner...")
+        logger.info("Initializing benchmark runner...")
         runner = BenchmarkRunner(config)
-        print()
 
         # Run benchmark
-        print("Starting benchmark execution...")
+        logger.info("Starting benchmark execution...")
         results = runner.run()
-        print(f"\nBenchmark complete! Generated {len(results)} results.")
-        print()
-
-        # Generate output filename prefix
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_prefix = args.output_prefix or timestamp
+        logger.info("Benchmark complete. Generated %s result objects.", len(results))
 
         # Save individual results
-        results_dir = Path(config.input_output.results_directory)
-        results_dir.mkdir(parents=True, exist_ok=True)
-
-        results_file = results_dir / f"results_{output_prefix}.json"
-        print(f"Saving results to {results_file}...")
+        results_file = run_dir / "results.json"
+        logger.info("Saving results to %s...", results_file)
         IOUtils.save_results(results, str(results_file))
 
         # Aggregate and save if requested
         if not args.no_aggregate:
-            print("\nAggregating results...")
+            logger.info("Aggregating results...")
             aggregated = ResultsAggregator.aggregate(results, config.name)
 
-            aggregated_file = results_dir / f"aggregated_{output_prefix}.json"
-            print(f"Saving aggregated results to {aggregated_file}...")
+            aggregated_file = run_dir / "aggregated.json"
+            logger.info("Saving aggregated results to %s...", aggregated_file)
             IOUtils.save_aggregated_results(aggregated, str(aggregated_file))
 
             # Generate standard summary
-            print("\n" + "=" * 70)
             summary = ResultsReporter.generate_summary(aggregated)
 
             # Extract and Append Qualitative Reasoning
@@ -183,29 +222,24 @@ def main() -> int:
                 summary_str = summary
 
             # Print the FULL summary (Statistics + Reasoning)
-            print(summary_str)
+            logger.info("\n%s", summary_str)
 
             # Save summary to text file
-            summary_file = results_dir / f"summary_{output_prefix}.txt"
-            with open(summary_file, "w") as f:
+            summary_file = run_dir / "summary.txt"
+            with open(summary_file, "w", encoding="utf-8") as f:
                 f.write(summary_str)
-            print(f"\nSummary saved to {summary_file}")
+            logger.info("Summary saved to %s", summary_file)
 
-        print("\n" + "=" * 70)
-        print("BENCHMARK COMPLETE")
-        print("=" * 70)
+        logger.info("BENCHMARK COMPLETE")
 
         return 0
 
     except KeyboardInterrupt:
-        print("\n\nBenchmark interrupted by user.")
+        logging.getLogger(__name__).warning("Benchmark interrupted by user.")
         return 130
 
     except Exception as e:
-        print(f"\nError: {e}", file=sys.stderr)
-        import traceback
-
-        traceback.print_exc()
+        logging.getLogger(__name__).exception("Error: %s", e)
         return 1
 
 

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -1,6 +1,7 @@
 """I/O utilities for loading and saving data."""
 
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import List
@@ -81,12 +82,13 @@ class IOUtils:
             raise FileNotFoundError(f"Quiz directory not found: {quiz_directory}")
 
         quizzes = []
+        logger = logging.getLogger(__name__)
         for quiz_file in quiz_dir.glob("*.json"):
             try:
                 quiz = IOUtils.load_quiz(str(quiz_file))
                 quizzes.append(quiz)
             except Exception as e:
-                print(f"Warning: Failed to load {quiz_file}: {e}")
+                logger.warning("Failed to load %s: %s", quiz_file, e)
 
         return quizzes
 

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -1,0 +1,38 @@
+"""Centralized logging configuration utilities."""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+
+def setup_logging(debug: bool = False, log_file: Optional[Path] = None) -> None:
+    """Configure console/file logging for benchmark runs.
+
+    Args:
+        debug: If True, emit DEBUG logs to console.
+        log_file: Optional path for a full DEBUG log file.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+
+    # Reset existing handlers so setup can be called more than once.
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+
+    console_level = logging.DEBUG if debug else logging.INFO
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(console_level)
+    console_handler.setFormatter(logging.Formatter("%(message)s"))
+    root_logger.addHandler(console_handler)
+
+    if log_file is not None:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
+        root_logger.addHandler(file_handler)


### PR DESCRIPTION
## Summary
This PR improves benchmark observability by introducing structured logging with clear verbosity levels and by packaging all run artifacts into a per-run results bundle.

## What Changed

### 1. Structured logging with clear verbosity behavior
- Added centralized logging setup in `src/utils/logging_utils.py`.
- Replaced ad-hoc `print(...)` output with Python logging in:
  - `main.py`
  - `src/runners/benchmark.py`
  - `src/utils/io.py`

Logging behavior now is:
- **Default run**: concise `INFO` messages in terminal.
- **Always-on full logs**: detailed `DEBUG` output written to `run.log` in the run bundle.
- **Debug mode**: `--debug` enables live `DEBUG` output in terminal.

### 2. Per-run artifact bundles
- Changed output writing in `main.py` from flat timestamped files to a run-specific directory.
- Each benchmark run now creates a readable bundle directory under `outputs.results_directory`.

Bundle contents:
- `results.json`
- `aggregated.json` (unless `--no-aggregate`)
- `summary.txt`
- `metadata.json`
- `run.log`

### 3. CLI updates
- Added `--debug` flag to control live terminal verbosity.
- `--output-prefix` now acts as a run bundle name override.

### 4. Documentation updates
- Removed run-bundle/logging details from `README.md`.
- Updated documentation pages to reflect the new output structure and logging behavior:
  - `docs/docs/user-manual/quick-start.md`
  - `docs/docs/user-manual/usage-guide.md`
  - `docs/docs/user-manual/example-workflows.md`
  - `docs/docs/user-manual/troubleshooting.md`
  - `docs/docs/contributor-guide/architecture.md`

## Why
- Improves developer and user experience by reducing noisy terminal output in normal runs.
- Preserves full diagnostics for reproducibility and debugging.
- Makes benchmark results easier to browse, share, and archive as a self-contained run bundle.

## Impact
- No metric scoring logic changed.
- Existing benchmark execution flow remains the same.
- Output file names/locations changed to bundle-based paths.

## Verification
- `ruff check src/ main.py` passed.
- `pytest -q` passed (`54 passed`).
